### PR TITLE
Ensure that unicode content is wire-safe by  setting the contentEncoding of the message

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -155,7 +155,8 @@ function Task(client, name, options) {
 		self.client.broker.publish(
 		self.options.queue || queue || self.client.conf.DEFAULT_QUEUE,
 		createMessage(self.name, args, kwargs, options, id), {
-			'contentType': 'application/json'
+			'contentType': 'application/json',
+			'contentEncoding': 'utf-8'
 		},
 		callback);
 		return new Result(id, self.client);


### PR DESCRIPTION
The current code fails when creating a celery task which contains unicode characters. This ensures it works in that scenario.
