### PR TITLE
Option for adding task result id prefixes in celery.js

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -159,7 +159,9 @@ function Task(client, name, options) {
         queue = route && route.queue;
 
     self.publish = function (args, kwargs, options, callback) {
-        var id = uuid.v4();
+        var id_prefix = self.options.id_prefix || self.client.conf.TASK_RESULT_ID_PREFIX || '',
+            id = id_prefix + uuid.v4();
+            
         self.client.broker.publish(
             self.options.queue || queue || self.client.conf.DEFAULT_QUEUE,
             createMessage(self.name, args, kwargs, options, id), {


### PR DESCRIPTION
Added the option to allow the user to specify a task result id prefix for tracking purposes
