### PR TITLE
fix(reds backend) - in Client() constructor function, if redis is used both as broker_type & backend_type then correctly set the backend property

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -124,7 +124,12 @@ function Client(conf) {
     }
 
     if (self.conf.backend_type === self.conf.broker_type) {
-        self.backend = self.broker;
+
+        if (self.conf.backend_type === 'redis') {
+          self.backend = self.broker.redis;
+        } else {
+          self.backend = self.broker;
+        }
         self.backend_connected = true;
     } else if (self.conf.backend_type === 'amqp') {
         self.backend = amqp.createConnection({


### PR DESCRIPTION
Would appreciate if you can review this change and accept it.