### PR TITLE
implement disconnect in RedisBroker

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -64,6 +64,10 @@ function RedisBroker(broker_url) {
     self.end = function() {
       self.redis.end();
     };
+    
+    self.disconnect = function() {
+        self.redis.end();
+    };
 
     self.redis.on('connect', function() {
         self.emit('ready');


### PR DESCRIPTION
This allows the celery client to shutdown gracefully when the broker is a redis instance. 
Earlier behavior was throw due to missing disconnect