### PR TITLE
Send UTC dates for expire

### DIFF
--- a/protocol.js
+++ b/protocol.js
@@ -5,7 +5,7 @@ var fields = ['task', 'id', 'args', 'kwargs', 'retries', 'eta', 'expires', 'queu
 
 
 function formatDate(date) {
-    return new Date(date).toISOString().slice(0, - 1);
+    return new Date(date).toISOString();
 }
 
 function createMessage(task, args, kwargs, options, id) {

--- a/tests/test_protocol.js
+++ b/tests/test_protocol.js
@@ -44,5 +44,17 @@ describe('protocol', function() {
                 id: "bar"
             });
         });
+
+        it('should send the expiry as UTC', function() {
+            assert.deepEqual(msg("foo", null, null, {
+                expires: Date.parse('Mon Nov 30 2015 10:03:37 GMT+0000 (UTC)')
+            }), {
+                task: "foo",
+                args: [],
+                kwargs: {},
+                expires: "2015-11-30T10:03:37.000Z",
+                id: "id"
+            });
+        });
     });
 });


### PR DESCRIPTION
I'm sure there must be a reason you slides of the timezone marker, but I'm not sure what it could be. To me it seems safer to always include the timezone marker, in case the servers are not running with the same timezone offset.