### PR TITLE
redis backend supports subscribe to task results

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -66,7 +66,7 @@ function RedisBroker(broker_url) {
     self.end = function() {
         self.redis.end(true);
     };
-    
+
     self.disconnect = function() {
         self.redis.quit();
     };
@@ -148,7 +148,7 @@ function RedisBackend(conf) {
 
     // store results to emit event when ready
     self.results = {};
-    
+
     // results prefix
     var key_prefix = 'celery-task-meta-';
 
@@ -157,7 +157,7 @@ function RedisBackend(conf) {
         // on redis result..
         self.redis.on('pmessage', function(pattern, channel, message) {
             backend_ex.expire(channel, conf.TASK_RESULT_EXPIRES / 1000);
-            var taskid = channel.slice(key_prefix.length);                
+            var taskid = channel.slice(key_prefix.length);
             if (self.results.hasOwnProperty(taskid)) {
                 var res = self.results[taskid];
                 res.result = JSON.parse(message);
@@ -166,8 +166,9 @@ function RedisBackend(conf) {
             }
         });
         // subscribe to redis results
-        self.redis.psubscribe(key_prefix + '*');
-        self.emit('ready');
+        self.redis.psubscribe(key_prefix + '*', () => {
+            self.emit('ready');
+        });
     });
 
     self.get = function(taskid, cb) {
@@ -211,7 +212,7 @@ function Client(conf) {
                 defaultExchangeName: self.conf.DEFAULT_EXCHANGE
             });
         }
-    
+
         self.broker.on('ready', function() {
             debug('Broker connected...');
             self.ready = true;

--- a/celery.js
+++ b/celery.js
@@ -33,18 +33,19 @@ function Configuration(options) {
     self.broker_type = url.parse(self.BROKER_URL).protocol.slice(0, -1);
     debug('Broker type: ' + self.broker_type);
 
-    if (self.RESULT_BACKEND && self.RESULT_BACKEND.toLowerCase() === 'amqp') {
-        self.backend_type = 'amqp';
-    } else if (self.RESULT_BACKEND && url.parse(self.RESULT_BACKEND)
-        .protocol === 'redis:') {
+    if (self.RESULT_BACKEND && url.parse(self.RESULT_BACKEND).protocol === 'redis:') {
         self.backend_type = 'redis';
+    } else {
+        self.backend_type = 'amqp';
     }
+    debug('Backend type: ' + self.backend_type);
 }
 
 function RedisBroker(broker_url) {
     var self = this;
     var purl = url.parse(broker_url);
     var database;
+
     if (purl.pathname) {
       database = purl.pathname.slice(1);
     }
@@ -63,11 +64,11 @@ function RedisBroker(broker_url) {
     }
 
     self.end = function() {
-      self.redis.end(true);
+        self.redis.end(true);
     };
     
     self.disconnect = function() {
-        self.redis.end(true);
+        self.redis.quit();
     };
 
     self.redis.on('connect', function() {
@@ -108,34 +109,84 @@ function RedisBroker(broker_url) {
 }
 util.inherits(RedisBroker, events.EventEmitter);
 
+function RedisBackend(conf) {
+    var self = this;
+    var purl = url.parse(conf.RESULT_BACKEND);
+    var database;
+
+    if (purl.pathname) {
+      database = purl.pathname.slice(1);
+    }
+
+    debug('Connecting to backend...');
+    self.redis = redis.createClient(purl.port, purl.hostname);
+    // needed because we'll use `psubscribe`
+    var backend_ex = self.redis.duplicate();
+
+    if (purl.auth) {
+        debug('Authenticating backend...');
+        self.redis.auth(purl.auth.split(':')[1]);
+        debug('Backend authenticated...');
+    }
+
+    if (database) {
+        self.redis.select(database);
+    }
+
+    self.redis.on('error', function(err) {
+        self.emit('error', err);
+    });
+
+    self.redis.on('end', function() {
+        self.emit('end');
+    });
+
+    self.quit = function() {
+        backend_ex.quit();
+        self.redis.quit();
+    };
+
+    // store results to emit event when ready
+    self.results = {};
+    
+    // results prefix
+    var key_prefix = 'celery-task-meta-';
+
+    self.redis.on('connect', function() {
+        debug('Backend connected...');
+        // on redis result..
+        self.redis.on('pmessage', function(pattern, channel, message) {
+            backend_ex.expire(channel, conf.TASK_RESULT_EXPIRES / 1000);
+            var taskid = channel.slice(key_prefix.length);                
+            if (self.results.hasOwnProperty(taskid)) {
+                var res = self.results[taskid];
+                res.result = JSON.parse(message);
+                res.emit('ready', res.result);
+                delete self.results[taskid];
+            }
+        });
+        // subscribe to redis results
+        self.redis.psubscribe(key_prefix + '*');
+        self.emit('ready');
+    });
+
+    self.get = function(taskid, cb) {
+        backend_ex.get(key_prefix + taskid, cb);
+    }
+
+    return self;
+}
+util.inherits(RedisBackend, events.EventEmitter);
 
 function Client(conf) {
     var self = this;
+    self.ready = false;
 
     self.conf = new Configuration(conf);
 
-    self.ready = false;
-    self.broker_connected = false;
-    self.backend_connected = false;
-
-    debug('Connecting to broker...');
-    if (self.conf.broker_type === 'amqp') {
-      self.broker = amqp.createConnection(
-        self.conf.BROKER_OPTIONS, {
-          defaultExchangeName: self.conf.DEFAULT_EXCHANGE
-      });
-    } else if (self.conf.broker_type === 'redis') {
-      self.broker = new RedisBroker(self.conf.BROKER_URL);
-    }
-
-    if (self.conf.backend_type === self.conf.broker_type) {
-
-        if (self.conf.backend_type === 'redis') {
-          self.backend = self.broker.redis;
-        } else {
-          self.backend = self.broker;
-        }
-        self.backend_connected = true;
+    // backend
+    if (self.conf.backend_type === 'redis') {
+        self.backend = new RedisBackend(self.conf);
     } else if (self.conf.backend_type === 'amqp') {
         self.backend = amqp.createConnection({
             url: self.conf.BROKER_URL,
@@ -143,75 +194,38 @@ function Client(conf) {
         }, {
             defaultExchangeName: self.conf.DEFAULT_EXCHANGE
         });
-    } else if (self.conf.backend_type === 'redis') {
-        var purl = url.parse(self.conf.RESULT_BACKEND),
-            database = purl.pathname.slice(1);
-        debug('Connecting to backend...');
-        self.backend = redis.createClient(purl.port, purl.hostname);
-
-        if (purl.auth) {
-            debug('Authenticating backend...');
-            self.backend.auth(purl.auth.split(':')[1]);
-            debug('Backend authenticated...');
+    } else if (self.conf.backend_type === self.conf.broker_type) {
+        if (self.conf.backend_type === 'amqp') {
+          self.backend = self.broker;
         }
-
-        if (database) {
-            self.backend.select(database);
-        }
-
-        // map to store results to emit event when ready
-        self.redis_results = new Map();
-        // results prefix
-        const redis_key_prefix = 'celery-task-meta-';
-        // needed because we'll use `psubscribe`
-        self.backend_ex = self.backend.duplicate();
-
-        self.backend.on('connect', function() {
-            debug('Backend connected...');
-            self.backend_connected = true;
-            if (self.broker_connected) {
-                self.ready = true;
-                debug('Emiting connect event...');
-                self.emit('connect');
-            }
-            // on redis result..
-            self.backend.on('pmessage', (pattern, channel, message) => {
-                self.backend_ex.expire(channel, self.conf.TASK_RESULT_EXPIRES / 1000);
-                const taskid = channel.slice(redis_key_prefix.length);
-                if (self.redis_results.has(taskid)) {
-                    const result = self.redis_results.get(taskid);
-                    result.result = JSON.parse(message);
-                    result.emit('ready', result.result);
-                    self.redis_results.delete(taskid);
-                }
-            });
-            // subscribe to redis results
-            self.backend.psubscribe(`${redis_key_prefix}*`);
-        });
-
-        self.backend.on('error', function(err) {
-            self.emit('error', err);
-        });
-    } else {
-        self.backend_connected = true;
     }
 
-    self.broker.on('ready', function() {
-        debug('Broker connected...');
-        self.broker_connected = true;
-        if (self.backend_connected) {
+    // backend ready...
+    self.backend.on('ready', function() {
+        debug('Connecting to broker...');
+
+        if (self.conf.broker_type === 'redis') {
+            self.broker = new RedisBroker(self.conf.BROKER_URL);
+        } else if (self.conf.broker_type === 'amqp') {
+            self.broker = amqp.createConnection(self.conf.BROKER_OPTIONS, {
+                defaultExchangeName: self.conf.DEFAULT_EXCHANGE
+            });
+        }
+    
+        self.broker.on('ready', function() {
+            debug('Broker connected...');
             self.ready = true;
             debug('Emiting connect event...');
             self.emit('connect');
-        }
-    });
+        });
 
-    self.broker.on('error', function(err) {
-        self.emit('error', err);
-    });
+        self.broker.on('error', function(err) {
+            self.emit('error', err);
+        });
 
-    self.broker.on('end', function() {
-        self.emit('end');
+        self.broker.on('end', function() {
+            self.emit('end');
+        });
     });
 }
 
@@ -223,7 +237,9 @@ Client.prototype.createTask = function(name, options, exchange) {
 
 Client.prototype.end = function() {
     this.broker.disconnect();
-    if (this.backend && this.broker !== this.backend) {
+    if (this.conf.backend_type === 'redis') {
+        this.backend.quit();
+    } else if (this.conf.broker_type !== this.conf.backend_type) {
         this.backend.quit();
     }
 };
@@ -267,6 +283,12 @@ function Task(client, name, options, exchange) {
     self.publish = function (args, kwargs, options, callback) {
         var id = options.id || uuid.v4();
 
+        var result = new Result(id, self.client);
+
+        if (client.conf.backend_type === 'redis') {
+            client.backend.results[result.taskid] = result;
+        }
+
         queue = options.queue || self.options.queue || queue || self.client.conf.DEFAULT_QUEUE;
         var msg = createMessage(self.name, args, kwargs, options, id);
         var pubOptions = {
@@ -278,12 +300,6 @@ function Task(client, name, options, exchange) {
             exchange.publish(queue, msg, pubOptions, callback);
         } else {
             self.client.broker.publish(queue, msg, pubOptions, callback);
-        }
-
-        const result = new Result(id, self.client);
-
-        if (client.conf.backend_type === 'redis') {
-            client.redis_results.set(result.taskid, result);
         }
 
         return result;
@@ -348,7 +364,7 @@ util.inherits(Result, events.EventEmitter);
 Result.prototype.get = function(callback) {
     var self = this;
     if (callback && self.result === null) {
-        self.client.backend_ex.get('celery-task-meta-' + self.taskid, function(err, reply) {
+        self.client.backend.get(self.taskid, function(err, reply) {
             self.result = JSON.parse(reply);
             callback(self.result);
         });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "2"
+
+services:
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+
+  rabbit:
+    image: rabbitmq
+    ports:
+      - "5672:5672"
+
+  celery_amqp:
+    image: celery
+    command: celery worker -A tasks --loglevel=INFO
+    volumes:
+      - "./tests/tasks.py:/home/user/tasks.py"
+    depends_on:
+      - rabbit
+  
+  celery_redis:
+    image: celery
+    command: celery worker -A tasks --loglevel=INFO
+    volumes:
+      - "./tests/tasks.py:/home/user/tasks.py"
+    environment:
+      - CELERY_BROKER_URL=redis://redis/0
+      - CELERY_BACKEND_URL=redis://redis/0
+    depends_on:
+      - redis

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "0.2.7",
     "description": "Celery client for Node",
     "author": "Mher Movsisyan <mher.movsisyan@gmail.com>",
+    "scripts": {
+        "test": "mocha tests"
+    },
     "dependencies": {
         "amqp": "*",
         "node-uuid": "*",

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,14 +1,13 @@
+import os
 import logging
-
 from celery import Celery
 
-
-celery = Celery('tasks', broker='amqp://')
+backend = os.getenv('CELERY_BACKEND_URL', 'amqp')
+celery = Celery('tasks', backend=backend)
 
 celery.conf.update(
-        CELERY_RESULT_BACKEND = "amqp",
-        CELERY_RESULT_SERIALIZER='json',
-        )
+    CELERY_RESULT_SERIALIZER='json'
+)
 
 
 @celery.task
@@ -41,7 +40,3 @@ def echo(msg):
 @celery.task
 def send_email(to='me@example.com', title='hi'):
     logging.info("Sending email to '%s' with title '%s'" % (to, title))
-
-
-if __name__ == "__main__":
-    celery.start()

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -6,7 +6,8 @@ backend = os.getenv('CELERY_BACKEND_URL', 'amqp')
 celery = Celery('tasks', backend=backend)
 
 celery.conf.update(
-    CELERY_RESULT_SERIALIZER='json'
+    CELERY_RESULT_SERIALIZER='json',
+    CELERY_ENABLE_UTC=True
 )
 
 

--- a/tests/test_celery.js
+++ b/tests/test_celery.js
@@ -1,18 +1,23 @@
 var celery = require('../celery'),
     assert = require('assert');
 
-var conf = {
+// $ docker-compose up -d
+
+var conf_amqp = {
     CELERY_BROKER_URL: 'amqp://',
     CELERY_RESULT_BACKEND: 'amqp'
 };
+
 var conf_redis = {
-    CELERY_BROKER_URL: 'redis://'
+    CELERY_BROKER_URL: 'redis://',
+    CELERY_RESULT_BACKEND: 'redis://',
+    TASK_RESULT_EXPIRES: 5 // seconds
 };
 
 describe('celery functional tests', function() {
     describe('initialization', function() {
         it('should create a client without error', function(done) {
-            var client1 = celery.createClient(conf),
+            var client1 = celery.createClient(conf_amqp),
                 client2 = celery.createClient({
                     CELERY_BROKER_URL: 'amqp://foo'
                 });
@@ -46,7 +51,7 @@ describe('celery functional tests', function() {
 
     describe('basic task calls', function() {
         it('should call a task without error', function(done) {
-            var client = celery.createClient(conf),
+            var client = celery.createClient(conf_amqp),
                 add = client.createTask('tasks.add');
 
             client.on('connect', function() {
@@ -82,8 +87,7 @@ describe('celery functional tests', function() {
 
     describe('result handling with amqp backend', function() {
         it('should return a task result', function(done) {
-            if (conf.CELERY_RESULT_BACKEND !== 'amqp') return done();
-            var client = celery.createClient(conf),
+            var client = celery.createClient(conf_amqp),
                 add = client.createTask('tasks.add');
 
             client.on('connect', function() {
@@ -102,8 +106,7 @@ describe('celery functional tests', function() {
 
     describe('result handling with redis backend', function() {
         it('should return a task result (poll)', function(done) {
-            if (conf.CELERY_RESULT_BACKEND === 'amqp') return done();
-            var client = celery.createClient(conf),
+            var client = celery.createClient(conf_redis),
                 add = client.createTask('tasks.add');
 
             client.on('connect', function() {
@@ -122,8 +125,7 @@ describe('celery functional tests', function() {
         });
 
         it('should return a task result (push)', function(done) {
-            if (conf.CELERY_RESULT_BACKEND === 'amqp') return done();
-            var client = celery.createClient(conf),
+            var client = celery.createClient(conf_redis),
                 add = client.createTask('tasks.add');
 
             client.on('connect', function() {
@@ -142,14 +144,12 @@ describe('celery functional tests', function() {
 
     describe('eta', function() {
         it('should call a task with a delay', function(done) {
-            if (conf.CELERY_RESULT_BACKEND !== 'amqp') return done();
-            var client = celery.createClient(conf),
+            var client = celery.createClient(conf_amqp),
                 time = client.createTask('tasks.time');
 
             client.on('connect', function() {
-                var start = new Date()
-                    .getTime(),
-                    eta = new Date(start + 100000);
+                var start = new Date().getTime(),
+                    eta = new Date(start + 1000);
                 var result = time.call(null, null, {
                     eta: eta
                 });
@@ -167,8 +167,7 @@ describe('celery functional tests', function() {
 
     describe('expires', function() {
         it('should call a task which expires', function(done) {
-            if (conf.CELERY_RESULT_BACKEND !== 'amqp') return done();
-            var client = celery.createClient(conf),
+            var client = celery.createClient(conf_amqp),
                 time = client.createTask('tasks.time');
 
             client.on('connect', function() {

--- a/tests/test_celery.js
+++ b/tests/test_celery.js
@@ -3,24 +3,25 @@ var celery = require('../celery'),
 
 // $ docker-compose up -d
 
+var conf_invalid = {
+    CELERY_BROKER_URL: 'amqp://foo'
+}
+
 var conf_amqp = {
-    CELERY_BROKER_URL: 'amqp://',
-    CELERY_RESULT_BACKEND: 'amqp'
+    CELERY_BROKER_URL: 'amqp://'
 };
 
 var conf_redis = {
     CELERY_BROKER_URL: 'redis://',
     CELERY_RESULT_BACKEND: 'redis://',
-    TASK_RESULT_EXPIRES: 5 // seconds
+    TASK_RESULT_EXPIRES: 1 // seconds
 };
 
 describe('celery functional tests', function() {
     describe('initialization', function() {
         it('should create a client without error', function(done) {
             var client1 = celery.createClient(conf_amqp),
-                client2 = celery.createClient({
-                    CELERY_BROKER_URL: 'amqp://foo'
-                });
+                client2 = celery.createClient(conf_invalid);
 
             client1.on('connect', function() {
                 client1.end();


### PR DESCRIPTION
Added support to subscribe to results (no need to poll) when using redis backend, also sets expiritaion on tasks in redis backend as well.

Moreover added a `docker-compose.yml` to make testing easier, running two celery instances, one for amqp and one for redis backend/broker testing.

```
$ docker-compose up -d
$ npm test
```
