### PR TITLE
Possible to IGNORE_RESULT for amqp

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -26,6 +26,7 @@ function Configuration(options) {
     self.DEFAULT_EXCHANGE_TYPE = self.DEFAULT_EXCHANGE_TYPE || 'direct';
     self.DEFAULT_ROUTING_KEY = self.DEFAULT_ROUTING_KEY || 'celery';
     self.RESULT_EXCHANGE = self.RESULT_EXCHANGE || 'celeryresults';
+    self.IGNORE_RESULT = self.IGNORE_RESULT || false;
     self.TASK_RESULT_EXPIRES = self.TASK_RESULT_EXPIRES * 1000 || 86400000; // Default 1 day
     self.TASK_RESULT_DURABLE = undefined !== self.TASK_RESULT_DURABLE ? self.TASK_RESULT_DURABLE : true; // Set Durable true by default (Celery 3.1.7)
     self.ROUTES = self.ROUTES || {};
@@ -287,7 +288,7 @@ function Result(taskid, client) {
     self.client = client;
     self.result = null;
 
-    if (self.client.conf.backend_type === 'amqp') {
+    if (self.client.conf.backend_type === 'amqp' && !self.client.conf.IGNORE_RESULT) {
         debug('Subscribing to result queue...');
         self.client.backend.queue(
             self.taskid.replace(/-/g, ''), {


### PR DESCRIPTION
Hi! An thanks for an awesome module <3

For many of my Celery tasks I don't care about the result. So I use the `CELERY_IGNORE_RESULT` option quite a bit, even for messages over `amqp`. This is just a quick PR for the change that made this work for me. It might be insufficient to fully support this feature. Also, no test - sorry. Please include a `npm test` script so I know how to run them :wink: 

In any case, without this change I get hit by a looping #35.

Regards,
Asbjørn
