### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -3,7 +3,7 @@ var url = require('url'),
     amqp = require('amqp'),
     redis = require('redis'),
     events = require('events'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 var createMessage = require('./protocol').createMessage;
 

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "node-celery",
-    "version": "0.2.8",
-    "description": "Celery client for Node",
-    "author": "Mher Movsisyan <mher.movsisyan@gmail.com>",
-    "scripts": {
-        "test": "mocha tests"
-    },
-    "dependencies": {
-        "amqp": "*",
-        "node-uuid": "*",
-        "redis": "*"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/mher/node-celery.git"
-    },
-    "devDependencies": {
-        "mocha": "*"
-    },
-    "engine": "node >= 0.8.2",
-    "main": "celery.js"
+  "name": "node-celery",
+  "version": "0.2.8",
+  "description": "Celery client for Node",
+  "author": "Mher Movsisyan <mher.movsisyan@gmail.com>",
+  "scripts": {
+    "test": "mocha tests"
+  },
+  "dependencies": {
+    "amqp": "*",
+    "redis": "*",
+    "uuid": "^3.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mher/node-celery.git"
+  },
+  "devDependencies": {
+    "mocha": "*"
+  },
+  "engine": "node >= 0.8.2",
+  "main": "celery.js"
 }

--- a/protocol.js
+++ b/protocol.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var fields = ['task', 'id', 'args', 'kwargs', 'retries', 'eta', 'expires', 'queue',
               'taskset', 'chord', 'utc', 'callbacks', 'errbacks', 'timeouts'];

--- a/tests/test_protocol.js
+++ b/tests/test_protocol.js
@@ -1,5 +1,5 @@
 var assert = require('assert'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     createMessage = require('../protocol')
         .createMessage;
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.