### PR TITLE
add rpc protocol since celery 4.0

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -9,7 +9,7 @@ var createMessage = require('./protocol').createMessage;
 
 var debug = process.env.NODE_CELERY_DEBUG === '1' ? console.info : function() {};
 
-var supportedProtocols = ['amqp', 'amqps', 'redis'];
+var supportedProtocols = ['amqp', 'amqps', 'redis', 'rpc'];
 function getProtocol(kind, options) {
     const protocol = url.parse(options.url).protocol.slice(0, -1);
     if (protocol === 'amqps') {


### PR DESCRIPTION
```js
client = celery.createClient({
		CELERY_BROKER_URL: 'amqp://guest:guest@localhost:5672//',
		CELERY_RESULT_BACKEND: 'rpc://' // celery 4.x
	});
```