### PR TITLE
Consistent connections for backend

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -211,10 +211,7 @@ function Client(conf) {
             self.emit('message', msg);
         });
     } else if (self.conf.backend_type === 'amqp') {
-        self.backend = amqp.createConnection({
-            url: self.conf.BROKER_URL,
-            heartbeat: 580
-        }, {
+        self.backend = amqp.createConnection(self.conf.BROKER_OPTIONS, {
             defaultExchangeName: self.conf.DEFAULT_EXCHANGE
         });
     } else if (self.conf.backend_type === self.conf.broker_type) {

--- a/celery.js
+++ b/celery.js
@@ -214,10 +214,6 @@ function Client(conf) {
         self.backend = amqp.createConnection(self.conf.BROKER_OPTIONS, {
             defaultExchangeName: self.conf.DEFAULT_EXCHANGE
         });
-    } else if (self.conf.backend_type === self.conf.broker_type) {
-        if (self.conf.backend_type === 'amqp') {
-          self.backend = self.broker;
-        }
     }
 
     // backend ready...

--- a/celery.js
+++ b/celery.js
@@ -216,6 +216,10 @@ function Client(conf) {
         });
     }
 
+    self.backend.on('error', function(err) {
+        self.emit('error', err);
+    });
+
     // backend ready...
     self.backend.on('ready', function() {
         debug('Connecting to broker...');


### PR DESCRIPTION
This simplifies the backend connection so it uses the same options as the broker. It also removes a case that can never happen (backend type must be either redis or amqp, there are no other options).

Finally it adds a missing error listener for the backend.